### PR TITLE
Enable streaming

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ pkg_check_modules(DEPS REQUIRED
         gio-2.0
         gmodule-2.0
         gstreamer-1.0
+        gstreamer-audio-1.0
         dbus-glib-1
         granite)
 
@@ -67,6 +68,7 @@ PACKAGES
     gio-2.0
     gmodule-2.0
     gstreamer-1.0
+    gstreamer-audio-1.0
     dbus-glib-1
     granite
 )

--- a/debian/control
+++ b/debian/control
@@ -8,6 +8,7 @@ Build-Depends: cmake (>= 2.8),
                libgtk-3-dev,
                libgranite-dev,
                libgstreamer1.0-dev,
+               libgstreamer-plugins-base1.0-dev,
                libdbus-glib-1-dev,
                libgio2.0-cil-dev,
                valac-0.26 | valac (>= 0.26)


### PR DESCRIPTION
 - [ ] **museic_streamplayer:** enable stream output to file or buffer where bytes can be readed
 - [ ] **museic**: each second bytes from stream are readed from file (or used structure), stored and cleaned from file (or used structure)
 - [ ] **museic_remote:** Add request for stream that provides the bytes of the stream stored by museic
 - [ ] **client:** Add methods to request stream from client
 - [ ] **client:** Add methods to play stream bytearray from client
 - [ ]  **museic_gui**: add button to activate/deacivate streaming

When steaming, stream output is redirectioned so it's not played locally.